### PR TITLE
Fix bad peer dependency for Stencil v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "less": "^3.9.0"
   },
   "peerDependencies": {
-    "@stencil/core": "^1.0.2"
+    "@stencil/core": ">=1.0.2"
   },
   "devDependencies": {
     "@stencil/core": "^1.0.2",


### PR DESCRIPTION
Somehow we had this working in our project for a while, but after some recent packaging updates we've run into a problem with the peer dependency version for `@stencil/core`.  Looks like `stencil-sass` went through a similar revision at one point.