### PR TITLE
chore(repo): prepare to transfer to community

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@stencil/less",
+  "name": "@stencil-community/less",
   "version": "1.0.0",
   "license": "MIT",
   "main": "dist/index.cjs.js",
@@ -40,7 +40,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ionic-team/stencil-less.git"
+    "url": "git+https://github.com/stencil-community/stencil-less.git"
   },
   "author": "Ionic Team",
   "homepage": "https://stenciljs.com/",

--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,11 @@
-# @stencil/less
+# @stencil-community/less
 
 This package is used to easily precompile Less files within the Stencil components.
 
 First, npm install within the project:
 
 ```bash
-npm install @stencil/less --save-dev
+npm install @stencil-community/less --save-dev
 ```
 
 Next, within the project's `stencil.config.js` file, import the plugin and add it to the config's `plugins` config:
@@ -13,7 +13,7 @@ Next, within the project's `stencil.config.js` file, import the plugin and add i
 #### stencil.config.ts
 ```ts
 import { Config } from '@stencil/core';
-import { less } from '@stencil/less';
+import { less } from '@stencil-community/less';
 
 export const config: Config = {
   plugins: [


### PR DESCRIPTION
this commit updates the package name, references, and links to use the `stencil-community` github organization and `@stencil-community` npm scope. we will be transferring this to the stencil community to maintain.